### PR TITLE
Fest view merge master

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ SECRET_KEY = 'this_is_a_secret'
 CELERY_BROKER_URL = 'redis://localhost:6379/0'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
 CELERY_TASK_RESULT_EXPIRES = 3600
-IS_ASYNC = False
+IS_ASYNC = True
 
 class BaseConfig(object):
 

--- a/library/app.py
+++ b/library/app.py
@@ -23,6 +23,6 @@ mysql = MySQL()
 # mysql configurations
 app.config['MYSQL_DATABASE_USER'] = 'root'
 app.config['MYSQL_DATABASE_DB'] = 'festify'
-app.config['MYSQL_DATABASE_PASSWORD'] = ''
+app.config['MYSQL_DATABASE_PASSWORD'] = 'uberschall'
 app.config['MYSQL_DATABASE_HOST'] = 'localhost'
 mysql.init_app(app)

--- a/library/app.py
+++ b/library/app.py
@@ -23,6 +23,6 @@ mysql = MySQL()
 # mysql configurations
 app.config['MYSQL_DATABASE_USER'] = 'root'
 app.config['MYSQL_DATABASE_DB'] = 'festify'
-app.config['MYSQL_DATABASE_PASSWORD'] = 'uberschall'
+app.config['MYSQL_DATABASE_PASSWORD'] = ''
 app.config['MYSQL_DATABASE_HOST'] = 'localhost'
 mysql.init_app(app)

--- a/library/app.py
+++ b/library/app.py
@@ -23,6 +23,5 @@ mysql = MySQL()
 # mysql configurations
 app.config['MYSQL_DATABASE_USER'] = 'root'
 app.config['MYSQL_DATABASE_DB'] = 'festify'
-app.config['MYSQL_DATABASE_PASSWORD'] = ''
 app.config['MYSQL_DATABASE_HOST'] = 'localhost'
 mysql.init_app(app)

--- a/library/auth.py
+++ b/library/auth.py
@@ -175,7 +175,7 @@ def new():
     return redirect(url_for('festival', url_slug=new_url_slug))
 
 
-@app.route('/festival/<url_slug>')
+@app.route('/festival/<url_slug>', methods=['GET', 'POST'])
 def festival(url_slug):
     print 'url_slug....', url_slug
     current_festival = db.get_info_from_database(url_slug)

--- a/library/auth.py
+++ b/library/auth.py
@@ -16,7 +16,10 @@ from flask import render_template, request, redirect, url_for, session, flash
 import redis
 import spotipy
 import spotipy.util as util
+import os
 import base64
+import hashlib
+import datetime
 import requests
 import helpers
 import db
@@ -149,7 +152,9 @@ def home(config=BaseConfig):
             current_user = User.users[session.get('user_id')].access
             s = spotipy.Spotify(auth=current_user)
 
-
+    if request.method == 'POST':
+        url_slug = request.form['festival_id']
+        return redirect(url_for('festival', url_slug=url_slug))
     return render_template('home.html', login=True)
 
 
@@ -158,9 +163,79 @@ def set_prep():
     pass
 
 
+@app.route('/festival/create_new', methods=['GET'])
+def new():
+    current_user = session.get('user_id')
+    unique = base64.b64encode(os.urandom(3))
+    slug_hash = hashlib.md5(current_user + str(datetime.datetime.now()) + unique)
+    new_url_slug = slug_hash.hexdigest()[:7]
+    new_catalog = helpers.Catalog('your-catalog', 'general')
+    db.save_to_database(None, current_user, None, None, new_catalog.id, new_url_slug)
+    print 'saving to db....'
+    return redirect(url_for('festival', url_slug=new_url_slug))
 
-@app.route('/results', methods=['POST', 'GET'])
-def results():
+
+@app.route('/festival/<url_slug>')
+def festival(url_slug):
+    print 'url_slug....', url_slug
+    current_festival = db.get_info_from_database(url_slug)
+    if not current_festival:
+        return redirect(url_for('home'))
+    new = None
+    new_artist = None
+    searchform = frontend_helpers.SearchForm()
+    suggested_pl_butt = frontend_helpers.SuggestedPlaylistButton()
+    art_select = frontend_helpers.ArtistSelect(request.form)
+    params_form = frontend_helpers.ParamsForm()
+
+    current_user = load_user(session.get('user_id')).access
+    s = spotipy.Spotify(auth=current_user)   
+    try:
+        processor = helpers.AsyncAdapter(app)
+        artists = processor.get_user_preferences(s)
+        print (artists)
+        User.artists = artists
+    except:
+        print ("No artists followed found in the user's Spotify account.")
+        User.artists = set()
+    else:
+        if searchform.validate_on_submit():
+            new_artist = searchform.artist_search.data
+            User.search_results = helpers.search_artist_echonest(new_artist)
+            art_select.artist_display.choices = User.search_results
+            if not User.search_results:
+                new = -1
+
+        if art_select.artist_display.data:
+            if art_select.is_submitted():
+                option_n = int(art_select.artist_display.data) -1
+                chosen_art = User.search_results[option_n][1]
+                if chosen_art not in User.artists:
+                    User.artists.update([chosen_art])
+                    new_artist = chosen_art
+                    new = 1
+                else:
+                    new = 0
+
+        elif suggested_pl_butt.validate_on_submit():
+            if request.form.get("add_button"):
+                new_artist = ', '.join(suggested_artists)
+                User.artists.update(suggested_artists)
+                new = True    
+    return render_template('festival.html', url_slug=url_slug, searchform=searchform,
+                            art_select=art_select,
+                            suggested_pl_butt=suggested_pl_butt,
+                            artists=User.artists,
+                            params_form=params_form,
+                            new=new, new_artist=new_artist)
+
+
+@app.route('/festival/<url_slug>/results', methods=['POST', 'GET'])
+def results(url_slug):
+    current_festival = db.get_info_from_database(url_slug)
+    festival_catalog = current_festival[4]
+    print 'CURRENT FESTIVAL', current_festival
+    print "CATALOG IS...", festival_catalog
     if request.method == 'POST':
         # Did user click on join festival ?
         try:
@@ -195,7 +270,7 @@ def results():
         user_id = s.me()['id']
 
         processor = helpers.AsyncAdapter(app)
-        catalog = helpers.random_catalog(User.artists)
+        catalog = helpers.random_catalog(User.artists, catalog_id=festival_catalog)
         playlist = helpers.seed_playlist(catalog=catalog, hotttnesss=h,
                                          danceability=d, energy=e, variety=v)
         songs_id = processor.process_spotify_ids(50, 10, s, playlist)
@@ -219,65 +294,8 @@ def results():
             helpers.add_songs_to_playlist(s, user_id, id_playlist, songs_id)
             playlist_url = 'https://embed.spotify.com/?uri=spotify:user:' + str(user_id) + ':playlist:' + str(id_playlist)
             if app.config['IS_ASYNC'] is True:
-                db.save_to_database.apply_async(args=[name, user_id, id_playlist, playlist_url, catalog.id])
+                db.update_festival.apply_async(args=[name, id_playlist, playlist_url, url_slug])
             else:
-                db.save_to_database(name, user_id, id_playlist, playlist_url, catalog.id)
+                db.update_festival(name, id_playlist, playlist_url, url_slug)
             return render_template('results.html', playlist_url=playlist_url,
                                     enough_data=enough_data)
-
-
-@app.route('/festival/create_new')
-def new():
-    new = None
-    new_artist = None
-    searchform = frontend_helpers.SearchForm()
-    suggested_pl_butt = frontend_helpers.SuggestedPlaylistButton()
-    art_select = frontend_helpers.ArtistSelect(request.form)
-    params_form = frontend_helpers.ParamsForm()
-
-    current_user = User.users[session.get('user_id')].access
-    s = spotipy.Spotify(auth=current_user)    
-    try:
-        processor = helpers.AsyncAdapter(app)
-        artists = processor.get_user_preferences(s)
-        print (artists)
-        User.artists = artists
-    except:
-        print ("No artists followed found in the user's Spotify account.")
-        User.artists = set()
-    else:
-        if searchform.validate_on_submit():
-            new_artist = searchform.artist_search.data
-            User.search_results = helpers.search_artist_echonest(new_artist)
-            art_select.artist_display.choices = User.search_results
-            if not User.search_results:
-                new = -1
-
-        if art_select.artist_display.data:
-            if art_select.is_submitted():
-                option_n = int(art_select.artist_display.data) -1
-                chosen_art = User.search_results[option_n][1]
-                if chosen_art not in User.artists:
-                    User.artists.update([chosen_art])
-                    new_artist = chosen_art
-                    new = 1
-                else:
-                    new = 0
-
-
-        elif suggested_pl_butt.validate_on_submit():
-            if request.form.get("add_button"):
-                new_artist = ', '.join(suggested_artists)
-                User.artists.update(suggested_artists)
-                new = True    
-    return render_template('festival.html', searchform=searchform,
-                            art_select=art_select,
-                            suggested_pl_butt=suggested_pl_butt,
-                            artists=User.artists,
-                            params_form=params_form,
-                            new=new, new_artist=new_artist)
-
-@app.route('/festival/<url_slug>')
-def festival(url_slug):
-
-    return

--- a/library/auth.py
+++ b/library/auth.py
@@ -64,6 +64,7 @@ class User(UserMixin):
         else:
             return None
 
+
 @login_manager.user_loader
 def load_user(user_id):
     return User.get(user_id)

--- a/library/db.py
+++ b/library/db.py
@@ -1,8 +1,9 @@
 import base64
+import datetime
 from library.app import app, mysql, celery
 
 
-@celery.task(name='save_to_database')
+@celery.task(name='save_festival')
 def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId):
     '''
     saves infromation the data base.
@@ -13,7 +14,7 @@ def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId):
     playlistId = str(playlistId)
     playlistURL = str(playlistURL)
     catalogId = str(catalogId)
-    url_slug = str(base64.b64encode(userId + playlistURL))[:7]
+    url_slug = str(base64.b64encode(userId + festivalName +str(datetime.datetime.now())))[:7]
     values = (festivalName, userId, playlistId, playlistURL, catalogId, url_slug)
     with app.app_context():
         connection = mysql.connect()
@@ -23,6 +24,9 @@ def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId):
         print 'saved to database'
     return
 
+@celery.task(name='update_festival')
+def update_festival(festivalName, userId, playlistId, playlistURL, catalogId):
+    return
 
 def get_info_from_database(festivalId):
     '''

--- a/library/db.py
+++ b/library/db.py
@@ -13,7 +13,7 @@ def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId):
     playlistId = str(playlistId)
     playlistURL = str(playlistURL)
     catalogId = str(catalogId)
-    url_slug = str(base64.b64encode(festivalName + playlistURL))[:7]
+    url_slug = str(base64.b64encode(userId + playlistURL))[:7]
     values = (festivalName, userId, playlistId, playlistURL, catalogId, url_slug)
     with app.app_context():
         connection = mysql.connect()

--- a/library/db.py
+++ b/library/db.py
@@ -4,7 +4,7 @@ from library.app import app, mysql, celery
 
 
 @celery.task(name='save_festival')
-def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId):
+def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId, urlSlug):
     '''
     saves infromation the data base.
     festivalId will be created automatically
@@ -14,8 +14,7 @@ def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId):
     playlistId = str(playlistId)
     playlistURL = str(playlistURL)
     catalogId = str(catalogId)
-    url_slug = str(base64.b64encode(userId + festivalName +str(datetime.datetime.now())))[:7]
-    values = (festivalName, userId, playlistId, playlistURL, catalogId, url_slug)
+    values = (festivalName, userId, playlistId, playlistURL, catalogId, urlSlug)
     with app.app_context():
         connection = mysql.connect()
         cursor = connection.cursor()
@@ -25,7 +24,15 @@ def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId):
     return
 
 @celery.task(name='update_festival')
-def update_festival(festivalName, userId, playlistId, playlistURL, catalogId):
+def update_festival(festivalName, playlistId, playlistURL, urlSlug):
+    values = (festivalName, playlistId, playlistURL, urlSlug)
+    with app.app_context():
+        connection = mysql.connect()
+        cursor = connection.cursor()
+        cursor.execute("UPDATE sessions SET festivalName=%s, playlistId=%s, playlistURL=%s WHERE urlSlug=%s",
+                        (festivalName, playlistId, playlistURL, urlSlug))
+        connection.commit()
+        print 'saved to database'
     return
 
 def save_contributor(festivalId, userId):
@@ -42,20 +49,24 @@ def save_contributor(festivalId, userId):
 
 
 
-def get_info_from_database(festivalId):
+def get_info_from_database(urlSlug):
     '''
     return a list with all the information from the
     database for a certain festival id
     '''
     connection = mysql.get_db()
     cursor = connection.cursor()
-    cursor.execute("SELECT * FROM sessions WHERE festivalId = %s", (festivalId,))
+    cursor.execute("SELECT * FROM sessions WHERE urlSlug = %s", (urlSlug,))
     data = cursor.fetchall()
+    if not data:
+        return None
+    print 'DATA', data
     festivalId = int(data[0][0])
-    userId = str(data[0][1])
-    playlistId = str(data[0][2])
-    playlistURL = str(data[0][3])
-    catalogId = str(data[0][4])
+    festivalName = str(data[0][1])
+    userId = str(data[0][2])
+    playlistId = str(data[0][3])
+    playlistURL = str(data[0][4])
+    catalogId = str(data[0][5])
     values = [festivalId, userId, playlistId, playlistURL, catalogId]
     return values
 

--- a/library/helpers.py
+++ b/library/helpers.py
@@ -231,8 +231,11 @@ def process_to_item(artist):
     return item
 
 
-def random_catalog(artists, limit=15):
-    catalog = Catalog('your_catalog', 'general')
+def random_catalog(artists, limit=15, catalog_id=None):
+    if catalog_id:
+        catalog = Catalog(catalog_id)
+    else:
+        catalog = Catalog('your_catalog', 'general')
     artists = list(artists)
     for _ in xrange(limit):
         choice = random.choice(artists)
@@ -261,7 +264,7 @@ def seed_playlist(catalog, danceability=0.5, hotttnesss=0.5,
                              min_energy=energy, variety=variety, distribution='focused',
                              results=results)
         print 'songs in playslist', len(pl)
-        catalog.delete()
+        #catalog.delete()
         return pl
 
 

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -15,7 +15,7 @@
 
 
 
-            <form action="{{ url_for('home') }}" method="POST">
+            <form action="{{ url_for('festival', url_slug=url_slug) }}" method="POST">
                 {{ searchform.hidden_tag() }}
                 {{ searchform.artist_search(size=20)}}
                 {{ searchform.submit }}
@@ -23,7 +23,7 @@
 
 
             {% if art_select.artist_display.choices %}
-                <form action="{{ url_for('home') }}" method="POST">
+                <form action="{{ url_for('festival', url_slug=url_slug) }}" method="POST">
 
                     {{ art_select.hidden_tag() }}
                     {{ art_select.artist_display }}

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+
+{% block lists %}
+
+       <div class="inner cover">
+
+            <form action="{{ url_for('home')}}" method="POST">
+                {{ suggested_pl_butt.hidden_tag() }}
+                {{ suggested_pl_butt.add_button }}
+            </form>
+
+
+
+            <p class="lead">Would you like to invite more artists?</p>
+
+
+
+            <form action="{{ url_for('home') }}" method="POST">
+                {{ searchform.hidden_tag() }}
+                {{ searchform.artist_search(size=20)}}
+                {{ searchform.submit }}
+            </form>
+
+
+            {% if art_select.artist_display.choices %}
+                <form action="{{ url_for('home') }}" method="POST">
+
+                    {{ art_select.hidden_tag() }}
+                    {{ art_select.artist_display }}
+                    {{ art_select.confirm_button }}
+
+                </form>
+
+            {% elif s_results == false %}
+                <p class="lead">No artists found with that name!</p>
+            {% endif %}
+
+
+            {% if new  == 1 %}
+                <h6 color="green" border=1>{{ new_artist }} added!</h6>
+            {% elif new == 0 %}
+                <h6 color="red"  border=1>{{ new_artist }} is already here.</h6>
+            {% elif new == -1 %}
+                <h6 color="red"  border=1>That artist will be born in the near future.</h6>
+            {% endif %}
+
+    	<div class="inner cover">
+    	    <h1 class="cover-heading">Let's see the set list!</h1>
+    	    <br>
+    	    <p class="lead">
+    	      <form action="{{ url_for('results') }}" method="post">
+                <fieldset>
+                {{ params_form.name.label }} <br>
+                {{ params_form.name }} <br>
+                {{ params_form.danceability.label }}
+                {{ params_form.danceability(min=0, max=1, oninput="outputUpdate(value)")}}
+                {{ params_form.hotttnesss.label}}
+                {{ params_form.hotttnesss(min=0, max=1, oninput="outputUpdate(value)")}}
+                {{ params_form.energy.label }}
+                {{ params_form.energy(min=0, max=1, oninput="outputUpdate(value)")}}
+                {{ params_form.variety.label }}
+                {{ params_form.variety(min=0, max=1, oninput="outputUpdate(value)")}}
+    	        <input class="btn btn-success btn-lg" type="submit" value="Generate"></input>
+                </fieldset>
+    	      </form>
+    	    </p>
+    	</div>
+
+            {% if artists %}
+                <h3>These artists grace you with their presence:</h3>
+                <!--
+                {% for artist in artists %}
+                    <li>
+                        {{ artist }}
+                    </li>
+                {% endfor %}
+                -->
+            {% else %}
+                <h3> We haven't been able to find any artists yet! <br>
+            {% endif %}
+
+	   </div>
+	   
+{% endblock %}

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -48,7 +48,7 @@
     	    <h1 class="cover-heading">Let's see the set list!</h1>
     	    <br>
     	    <p class="lead">
-    	      <form action="{{ url_for('results') }}" method="post">
+    	      <form action="{{ url_for('results', url_slug=url_slug) }}" method="post">
                 <fieldset>
                 {{ params_form.name.label }} <br>
                 {{ params_form.name }} <br>

--- a/library/templates/home.html
+++ b/library/templates/home.html
@@ -15,7 +15,7 @@
                             <ul>
                                 <li id="login">
                                     <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Join Festival  </a>
-                                        <form id="login-form" action="{{ url_for('results') }}" method="post">
+                                        <form id="login-form" action="{{ url_for('home') }}" method="post">
                                             <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
                                             <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
                                         </form>
@@ -36,7 +36,7 @@
                             <ul>
                                 <li id="login">
                                     <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Join Festival  </a>
-                                        <form id="login-form" action="{{ url_for('results') }}" method="post">
+                                        <form id="login-form" action="{{ url_for('home') }}" method="post">
                                             <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
                                             <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
                                         </form>

--- a/library/templates/home.html
+++ b/library/templates/home.html
@@ -24,86 +24,26 @@
                         </nav>
     </div>
    	{% else %}
-        <div class="inner cover">
 
-            <form action="{{ url_for('home')}}" method="POST">
-                {{ suggested_pl_butt.hidden_tag() }}
-                {{ suggested_pl_butt.add_button }}
-            </form>
+    <div class="inner cover">
+            <h1 class="cover-heading">Let's start your ideal Festival</h1>
+            <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will
+                enjoy this musical experience.</p>
+            <br>
 
-
-
-            <p class="lead">Would you like to invite more artists?</p>
-
-
-
-            <form action="{{ url_for('home') }}" method="POST">
-                {{ searchform.hidden_tag() }}
-                {{ searchform.artist_search(size=20)}}
-                {{ searchform.submit }}
-            </form>
-
-
-            {% if art_select.artist_display.choices %}
-                <form action="{{ url_for('home') }}" method="POST">
-
-                    {{ art_select.hidden_tag() }}
-                    {{ art_select.artist_display }}
-                    {{ art_select.confirm_button }}
-
-                </form>
-
-            {% elif s_results == false %}
-                <p class="lead">No artists found with that name!</p>
-            {% endif %}
-
-
-            {% if new  == 1 %}
-                <h6 color="green" border=1>{{ new_artist }} added!</h6>
-            {% elif new == 0 %}
-                <h6 color="red"  border=1>{{ new_artist }} is already here.</h6>
-            {% elif new == -1 %}
-                <h6 color="red"  border=1>That artist will be born in the near future.</h6>
-            {% endif %}
-
-    	<div class="inner cover">
-    	    <h1 class="cover-heading">Let's see the set list!</h1>
-    	    <br>
-    	    <p class="lead">
-    	      <form action="{{ url_for('results') }}" method="post">
-                <fieldset>
-                {{ params_form.name.label }} <br>
-                {{ params_form.name }} <br>
-                {{ params_form.danceability.label }}
-                {{ params_form.danceability(min=0, max=1, oninput="outputUpdate(value)")}}
-                {{ params_form.hotttnesss.label}}
-                {{ params_form.hotttnesss(min=0, max=1, oninput="outputUpdate(value)")}}
-                {{ params_form.energy.label }}
-                {{ params_form.energy(min=0, max=1, oninput="outputUpdate(value)")}}
-                {{ params_form.variety.label }}
-                {{ params_form.variety(min=0, max=1, oninput="outputUpdate(value)")}}
-    	        <input class="btn btn-success btn-lg" type="submit" value="Generate"></input>
-                </fieldset>
-    	      </form>
-    	    </p>
-    	</div>
-
-            {% if artists %}
-                <h3>These artists grace you with their presence:</h3>
-                <!--
-                {% for artist in artists %}
-                    <li>
-                        {{ artist }}
-                    </li>
-                {% endfor %}
-                -->
-            {% else %}
-                <h3> We haven't been able to find any artists yet! <br>
-            {% endif %}
-
-	   </div>
-
-
+                <a href="{{ url_for('new') }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
+                        <nav>
+                            <ul>
+                                <li id="login">
+                                    <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Join Festival  </a>
+                                        <form id="login-form" action="{{ url_for('results') }}" method="post">
+                                            <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
+                                            <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
+                                        </form>
+                                </li>
+                            </ul>
+                        </nav>
+    </div>
 
     {% endif %}
 


### PR DESCRIPTION
1) The login seems a little wonky now - after you log in and restart the server for testing purposes, you will end up needing to click create festival twice, or once and then join festival for things to work. Just a caveat

2) You'll notice a new route

@app.route('/festival/create_new', methods=['GET'])
def new():
     ...
The purpose of this view is to create a basic database entry for the festival (notice the passing in of None values), but we create the url_slug (it's a hash function made up of the user_id, current datetime and random bytes at the end to ensure uniqueness). and a catalog that will be referenced.

This is following the thought process that there's one catalog per festival. By default, the festival owner's preferences should be automatically loaded into the catalog. I don't think this is done at the moment as I was just trying to achieve flow at this point, but this was the intention.

After the festival has been created, you're redirected to its URL at:

@app.route('/festival/<url_slug>')
def festival(url_slug):
    ....
This is where you will adjust parameters and what not. When you click generate, the playlist information is saved in the corresponding dB entry based on the url_slug - not the festivalId (had to change that for this).

If User A were to give the festival ID (for the purpose of the end user, this is the url_slug, for us its the unique ID in mysql) to User B, he/she can input that in the join festival box, and be redirected to the festival URL, where their preferences will be loaded into the festival's catalog.