### PR TITLE
Ready butts

### DIFF
--- a/library/auth.py
+++ b/library/auth.py
@@ -222,7 +222,7 @@ def new():
     festivalId = current_festival[0]
     userId = current_festival[2]
     try:
-        db.save_contributor(festivalId, userId, organizer=1)
+        db.save_contributor(festivalId, userId, organizer=1, ready=1)
     except:
         print ("SAVING CONTRIBUTOR FAILED!")
     return redirect(url_for('festival', url_slug=new_url_slug))

--- a/library/auth.py
+++ b/library/auth.py
@@ -181,13 +181,15 @@ def join(url_slug):
         flash(("Festival '{}' does not exist! Please check"
                 " the code and try again.").format(url_slug))
         return redirect(url_for('home'))
-    owner = current_festival[2]
+    organizer = current_festival[2]
     _user = session.get('user_id')
-    if owner != _user:
+    if organizer != _user:
         try:
             db.save_contributor(current_festival[0], _user)
         except:
             print ("Contributor {} is already in the database.".format(_user))
+    else:
+        flash("Welcome back to your own festival!")
     return redirect(url_for('festival', url_slug=url_slug))
 
 
@@ -234,27 +236,27 @@ def festival(url_slug):
         flash(("Festival '{}' does not exist! Please check"
                "the code and try again.").format(url_slug))
         return redirect(url_for('home'))
-    owner = current_festival[2]
+    organizer = current_festival[2]
     _user = session.get('user_id')
-    is_owner = True
-    # check if owner & if so, find name
-    if owner != _user:
-        is_owner = False
+    is_org = True
+    # check if organizer & if so, find name
+    if organizer != _user:
+        is_org = False
         festival_name = current_festival[1]
-    elif owner == _user:
-        is_owner = True
+    elif organizer == _user:
+        is_org = True
         festival_name = None
     # fetch contributors: the 0th term = the main organizer!
     try:
         all_users = db.get_contributors(current_festival[0])
+        if all_users == None:
+            flash(("Festival '{}' is having problems. Please check with the "
+                "organizer. Try again later.").format(url_slug))
+            return redirect(url_for('home')) 
     except:
         flash(("Festival '{}' is having problems. Please check with the "
                 "organizer. Try again later.").format(url_slug))
         return redirect(url_for('home'))
-    all_contributors = [contributor['userId'] for contributor in all_users['contributors']]
-    print ("contributors: {}".format(all_contributors))
-    print ("organizer: {}".format(all_users['organizer']['userId']))
-    
     new = None
     new_artist = None
 
@@ -305,7 +307,7 @@ def festival(url_slug):
                            all_users=all_users,
                            festival_name=festival_name,
                            user=_user,
-                           new=new, new_artist=new_artist, is_owner=is_owner)
+                           new=new, new_artist=new_artist, is_org=is_org)
 
 
 

--- a/library/db.py
+++ b/library/db.py
@@ -71,14 +71,17 @@ def get_contributors(festivalId):
     connection = mysql.get_db()
     cursor = connection.cursor()
     try:
-        cursor.execute("SELECT userId FROM contributors WHERE\
+        cursor.execute("SELECT * FROM contributors WHERE\
                        (festivalId = %s AND organizer = 1)", (festivalId,))
     except:
         print ("Database can't be reached")
         return None
-    data1 = cursor.fetchall()
-    if data1:
-        all_users = [user[0].encode('utf-8') for user in data1]
+    d1 = cursor.fetchall()
+    if d1:
+        all_users = {'owner': {'userId': str(d1[0][1]), 'ready': int(d1[0][2]), 
+                                'hotness': float(d1[0][3]), 'danceability': float(d1[0][4]),
+                                'energy': float(d1[0][5]), 'variety': float(d1[0][6]),
+                                'variety': float(d1[0][7]), 'adventurousness': float(d1[0][8])}}
     else:
         print ("There is no organizer assigned.")
         return None
@@ -88,14 +91,26 @@ def get_contributors(festivalId):
         cursor = connection.cursor()
         cursor.execute("SELECT userId FROM contributors WHERE\
                        (festivalId = %s AND organizer = 0)", (festivalId,))
-        data2 = cursor.fetchall()
-        print ("contributors: {}".format(data2))
+        d2 = cursor.fetchall()
+        print ("contributors: {}".format(d2))
     except:
         print ("Database can't be reached..")
         return None
-    if data2:
-        contributors = [user[0].encode('utf-8') for user in data2]
-        all_users += contributors
+    if d2:
+        contributors = {{str(u[0][1]): {'ready': int(u[0][2]), 
+                        'hotness': float(u[0][3]), 
+                        'danceability': float(u[0][4]),
+                        'energy': float(u[0][5]), 
+                        'variety': float(u[0][6]),
+                        'variety': float(u[0][7]), 
+                        'adventurousness': float(u[0][8])}} for u in d2}
+        all_ready = 1
+        for contributor in contributors:
+            if contributor['ready'] == 0:
+                all_ready = 0
+                break
+
+        all_users.update({'contributors': contributors, 'all_ready': all_ready})
 
     print ('contributors retrieved from database: {}'.format(all_users))
     return all_users

--- a/library/db.py
+++ b/library/db.py
@@ -4,7 +4,8 @@ from library.app import app, mysql, celery
 
 
 @celery.task(name='save_festival')
-def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId, urlSlug):
+def save_to_database(festivalName, userId, playlistId,
+                     playlistURL, catalogId, urlSlug):
     '''
     saves infromation the data base.
     festivalId will be created automatically
@@ -18,7 +19,8 @@ def save_to_database(festivalName, userId, playlistId, playlistURL, catalogId, u
     with app.app_context():
         connection = mysql.connect()
         cursor = connection.cursor()
-        cursor.execute("INSERT INTO sessions (festivalName, userId, playlistId, playlistURL, catalogId, urlSlug) VALUES (%s, %s, %s, %s, %s, %s)", values)
+        cursor.execute("INSERT INTO sessions (festivalName, userId, playlistId, playlistURL, catalogId, urlSlug)\
+                        VALUES (%s, %s, %s, %s, %s, %s)", values)
         connection.commit()
         print 'saved to database'
     return
@@ -30,29 +32,31 @@ def update_festival(festivalName, playlistId, playlistURL, urlSlug):
     with app.app_context():
         connection = mysql.connect()
         cursor = connection.cursor()
-        cursor.execute("UPDATE sessions SET festivalName=%s, playlistId=%s, playlistURL=%s WHERE urlSlug=%s",
+        cursor.execute("UPDATE sessions SET festivalName=%s, playlistId=%s,\
+                        playlistURL=%s WHERE urlSlug=%s",
                         (festivalName, playlistId, playlistURL, urlSlug))
         connection.commit()
         print 'saved to database'
     return
 
 
-def save_contributor(festivalId, userId, ready=0, hotness=None, 
-                    danceability=None, energy=None, variety=None, advent=None,
-                    organizer=0):
+def save_contributor(festivalId, userId, ready=0, hotness=None,
+                     danceability=None, energy=None, variety=None, advent=None,
+                     organizer=0):
     '''
-    requires festivalId and userId, 
+    requires festivalId and userId,
     saves whatever else you also put in it in the contributor table
-    ''' 
+    '''
     festivalId = int(festivalId)
     userId = str(userId)
-    values = (festivalId, userId, ready, hotness, 
-                danceability, energy, variety, advent, organizer)
+    values = (festivalId, userId, ready, hotness,
+              danceability, energy, variety, advent, organizer)
     print ("Saving contributor {} to festival {}".format(userId, festivalId))
     with app.app_context():
         connection = mysql.connect()
         cursor = connection.cursor()
-        cursor.execute("INSERT INTO contributors VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)", values)
+        cursor.execute("INSERT INTO contributors VALUES\
+                       (%s, %s, %s, %s, %s, %s, %s, %s, %s)", values)
         connection.commit()
         print 'saved to database'
     return
@@ -67,7 +71,8 @@ def get_contributors(festivalId):
     connection = mysql.get_db()
     cursor = connection.cursor()
     try:
-        cursor.execute("SELECT userId FROM contributors WHERE (festivalId = %s AND organizer = 1)", (festivalId,))
+        cursor.execute("SELECT userId FROM contributors WHERE\
+                       (festivalId = %s AND organizer = 1)", (festivalId,))
     except:
         print ("Database can't be reached")
         return None
@@ -81,7 +86,8 @@ def get_contributors(festivalId):
     try:
         connection = mysql.get_db()
         cursor = connection.cursor()
-        cursor.execute("SELECT userId FROM contributors WHERE (festivalId = %s AND organizer = 0)", (festivalId,))
+        cursor.execute("SELECT userId FROM contributors WHERE\
+                       (festivalId = %s AND organizer = 0)", (festivalId,))
         data2 = cursor.fetchall()
         print ("contributors: {}".format(data2))
     except:
@@ -104,10 +110,9 @@ def get_info_from_database(urlSlug):
     with app.app_context():
         connection = mysql.get_db()
         cursor = connection.cursor()
-        try:
-             cursor.execute("SELECT * FROM sessions WHERE urlSlug = %s", (urlSlug,))
-             data = cursor.fetchall()
-        except:
+        cursor.execute("SELECT * FROM sessions WHERE urlSlug = %s", (urlSlug,))
+        data = cursor.fetchall()
+        if not data:
             return None
         print 'DATA', data
         festivalId = int(data[0][0])
@@ -116,5 +121,6 @@ def get_info_from_database(urlSlug):
         playlistId = str(data[0][3])
         playlistURL = str(data[0][4])
         catalogId = str(data[0][5])
-        values = [festivalId, festivalName, userId, playlistId, playlistURL, catalogId]
+        values = [festivalId, festivalName, userId,
+                  playlistId, playlistURL, catalogId]
         return values

--- a/library/db.py
+++ b/library/db.py
@@ -89,6 +89,7 @@ def get_contributors(festivalId):
     return a list with all the contributors id of
     the festival. THE FIRST contributor == organizer
     '''
+
     print type(festivalId)
     print (festivalId)
     connection = mysql.get_db()
@@ -96,48 +97,52 @@ def get_contributors(festivalId):
     try:
         cursor.execute("SELECT * FROM contributors WHERE\
                        (festivalId = %s AND organizer = 1)", (festivalId,))
+        d1 = cursor.fetchall()
     except:
         print ("Database can't be reached")
         return None
-    d1 = cursor.fetchall()
-    if d1:
-        all_users = {'owner': {'userId': str(d1[0][1]), 'ready': int(d1[0][2]), 
-                               'hotness': float(d1[0][3]), 
-                               'danceability': float(d1[0][4]),
-                               'energy': float(d1[0][5]), 
-                               'variety': float(d1[0][6]),
-                               'variety': float(d1[0][7]), 
-                               'adventurousness': float(d1[0][8])}}
     else:
-        print ("There is no organizer assigned.")
-        return None
+        print (d1)
+        if d1:
+            print ("going into the if now")
+            all_users = {'organizer': {'userId': str(d1[0][1]), 
+                                   'ready': int(d1[0][2]), 
+                                   'hotness': (d1[0][3]), 
+                                   'danceability': (d1[0][4]),
+                                   'energy': (d1[0][5]), 
+                                   'variety': (d1[0][6]),
+                                   'adventurousness': (d1[0][7])}}
+            print ("going out of the if now")
+        else:
+            print ("There is no organizer assigned.")
+            return None
+        print (all_users)
 
     try:
-        connection = mysql.get_db()
-        cursor = connection.cursor()
-        cursor.execute("SELECT userId FROM contributors WHERE\
+        cursor.execute("SELECT * FROM contributors WHERE\
                        (festivalId = %s AND organizer = 0)", (festivalId,))
         d2 = cursor.fetchall()
-        print ("contributors: {}".format(d2))
     except:
         print ("Database can't be reached..")
         return None
-    if d2:
-        contributors = {{str(u[0][1]): {'ready': int(u[0][2]), 
-                        'hotness': float(u[0][3]), 
-                        'danceability': float(u[0][4]),
-                        'energy': float(u[0][5]), 
-                        'variety': float(u[0][6]),
-                        'variety': float(u[0][7]), 
-                        'adventurousness': float(u[0][8])}} for u in d2}
-        all_ready = 1
-        for contributor in contributors:
-            if contributor['ready'] == 0:
-                all_ready = 0
-                break
-
-        all_users.update({'contributors': contributors, 'all_ready': all_ready})
-
+    else:
+        print (d2)
+        if d2:
+            contributors = {str(u[1]): {'ready': int(u[2]), 
+                                        'hotness': u[3], 
+                                        'danceability': u[4],
+                                        'energy': u[5], 
+                                        'variety': u[6],
+                                        'adventurousness': u[7]} for u in d2}
+            print (contributors)
+            all_ready = 1
+            for contributor in contributors:
+                if contributors[contributor]['ready'] == 0:
+                    all_ready = 0
+                    print ("a contributor isn't ready")
+                    break
+            all_users.update({'contributors': contributors, 'all_ready': all_ready})
+            print (all_users)
     print ('contributors retrieved from database: {}'.format(all_users))
     return all_users
 
@@ -188,4 +193,3 @@ def get_average_parameters(festivalId):
                               float(data[0][4])]
         print 'Average Parameter : ' + str(average_parameters)
         return average_parameters
-

--- a/library/frontend_helpers.py
+++ b/library/frontend_helpers.py
@@ -39,8 +39,8 @@ class ParamsForm(Form):
     adventurousness = DecimalRangeField('adventurousness',
                    [validators.NumberRange(min=0, max=1)],
                    default=0.5)
-    ready_butt = SubmitField("Save Preferences")   
-    unready_butt = SubmitField("Change Preferences") 
+    ready_butt = SubmitField("Propose Vision")   
+    unready_butt = SubmitField("Change Vision") 
 
 class SuggestedPlaylistButton(Form):
     add_button = SubmitField("Add the Festify team's favorites!")

--- a/library/frontend_helpers.py
+++ b/library/frontend_helpers.py
@@ -38,7 +38,9 @@ class ParamsForm(Form):
                    default=0.5)
     adventurousness = DecimalRangeField('adventurousness',
                    [validators.NumberRange(min=0, max=1)],
-                   default=0.5)   
+                   default=0.5)
+    ready_butt = SubmitField("Save Preferences")   
+    unready_butt = SubmitField("Change Preferences") 
 
 class SuggestedPlaylistButton(Form):
     add_button = SubmitField("Add the Festify team's favorites!")

--- a/library/static/stylesheet.css
+++ b/library/static/stylesheet.css
@@ -191,7 +191,7 @@ body {
     top: 0;
   }
   .mastfoot {
-    position: fixed;
+    position: relative;
     bottom: 0;
   }
   /* Start the vertical centering */

--- a/library/static/stylesheet.css
+++ b/library/static/stylesheet.css
@@ -187,11 +187,11 @@ body {
 @media (min-width: 768px) {
   /* Pull out the header and footer */
   .masthead {
-    position: fixed;
+    position: relative;
     top: 0;
   }
   .mastfoot {
-    position: relative;
+    position: fixed;
     bottom: 0;
   }
   /* Start the vertical centering */

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -124,7 +124,7 @@
  
         {% else %}
             <form id="login-form" action="{{ url_for('results', url_slug=url_slug) }}" method="post">
-                <p><input id="festivalSubmit" class="btn btn-primary btn-lg" type="submit" value="ALL READY Generate" /></p>
+                <p><input class="btn btn-primary btn-lg" type="submit" value="ALL READY Generate" /></p>
             </form>
 
         {% endif %}  

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -56,16 +56,17 @@
 <!-- Organizer avatar and contributor avatar -->
 
 <h1>{{ all_users['organizer']['userId'] }}'s
-    {% if is_owner == true %} festival 
+    {% if is_org == true %} festival 
     {% else %} {{ festival_name }} {% endif %}</h1>
 <iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ all_users['organizer']['userId'] }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
+
 {% if 'contributors' in all_users %}
     <h3>Contributors</h3>
     <div id='cover-container'>
     {% for contributor in all_users['contributors'] %}
         <div id='login-form text'>
             <iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ contributor }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
-            {% if contributor['ready'] == 1%}
+            {% if all_users['contributors'][contributor]['ready'] == 1%}
                 <p>...is set!</p>
             {% endif %}
         </div> 
@@ -75,66 +76,82 @@
 
 
 
-    <p class="lead">
-        {% if is_owner == true %}
-      <form action="{{ url_for('results', url_slug=url_slug) }}" method="post">
-        <fieldset>
-            {{ params_form.name.label }} <br>
-            {{ params_form.name }} <br>
+<p class="lead">
+    {% if is_org == true %}
+  <form action="{{ url_for('results', url_slug=url_slug) }}" method="post">
+    <fieldset>
+        {{ params_form.name.label }} <br>
+        {{ params_form.name }} <br>
+    {% else %}
+  <form action="{{ url_for('update_parameters', url_slug=url_slug) }}" method="post">
+    <fieldset>
+    {% endif %}
+
+    {{ params_form.danceability.label }}
+    {{ params_form.danceability(min=0, max=1, oninput="outputUpdate(value)")}}
+    {{ params_form.hotttnesss.label}}
+    {{ params_form.hotttnesss(min=0, max=1, oninput="outputUpdate(value)")}}
+    {{ params_form.energy.label }}
+    {{ params_form.energy(min=0, max=1, oninput="outputUpdate(value)")}}
+    {{ params_form.variety.label }}
+    {{ params_form.variety(min=0, max=1, oninput="outputUpdate(value)")}}
+    {{ params_form.adventurousness.label }}
+    {{ params_form.adventurousness(min=0, max=1, oninput="outputUpdate(value)")}} 
+
+    {% if not is_org %}
+        {% if all_users['contributors'][user]['ready'] == 0 %}
+            {{ params_form.ready_butt }}
         {% else %}
-      <form action="{{ url_for('update_parameters', url_slug=url_slug) }}" method="post">
-        <fieldset>
+           {{ params_form.unready_butt }}
         {% endif %}
 
-        {{ params_form.danceability.label }}
-        {{ params_form.danceability(min=0, max=1, oninput="outputUpdate(value)")}}
-        {{ params_form.hotttnesss.label}}
-        {{ params_form.hotttnesss(min=0, max=1, oninput="outputUpdate(value)")}}
-        {{ params_form.energy.label }}
-        {{ params_form.energy(min=0, max=1, oninput="outputUpdate(value)")}}
-        {{ params_form.variety.label }}
-        {{ params_form.variety(min=0, max=1, oninput="outputUpdate(value)")}}
-        {{ params_form.adventurousness.label }}
-        {{ params_form.adventurousness(min=0, max=1, oninput="outputUpdate(value)")}} 
+    {% elif is_org %}
+        {% if 'contributors' not in all_users %}
+            <input class="btn btn-success btn-lg" type="submit" value="SOLO generate"></input>
+        {% endif %}
 
-        {% if not is_owner %}
-            {% if all_users['contributors'][user]['ready'] == 0 %}
-                {{ params_form.ready_butt }}
-            {% else %}
-               {{ params_form.unready_butt }}
-            {% endif %}
-        {% elif is_owner %}
-            {% if 'contributors' not in all_users %}
-                <input class="btn btn-success btn-lg" type="submit" value="Generate"></input>
-            {% elif all_users['all_ready'] == 0 %}
-                <li id="login">
-                    <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Generate</a>
-                    <form id="login-form" action="{{ url_for('results', url_slug=url_slug) }}" method="post">
-                    <p>Not everyone has shared their vibes! Are you sure?"</p>
-                    <p><input class="btn btn-primary btn-lg" type="submit" value="Generate" /></p>
-                    </form>
-            {% else %}
-                <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Generate</a>
-            {% endif %}   
-        {% endif %}         
-        </fieldset>
-      </form>
-    </p>             	
+    <nav>
+    <ul>
+    <li id="login">
+        {% if all_users['all_ready'] == 0 %}
+          
+            <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">NOT EVERYONE READY Generate</a>
+
+            <form id="login-form" action="{{ url_for('results', url_slug=url_slug) }}" method="post">
+           <p>Not everyone has shared their vibes! Are you sure?"</p> 
+            <p><input id="festivalSubmit" class="btn btn-primary btn-lg" type="submit" value="Generate" placeholder="placeholder" /></p>-->
+        </form>
+ 
+        {% else %}
+            <form id="login-form" action="{{ url_for('results', url_slug=url_slug) }}" method="post">
+                <p><input id="festivalSubmit" class="btn btn-primary btn-lg" type="submit" value="ALL READY Generate" /></p>
+            </form>
+
+        {% endif %}  
+         </li>
+        </ul>
+        </nav>
+    {% endif %}         
+    </fieldset>
+  </form>
+</p>             	
 </div>
-
+<!--
     {% if artists %}
         <h3>These artists grace you with their presence:</h3>
-        <!--
+        
         {% for artist in artists %}
             <li>
                 {{ artist }}
             </li>
         {% endfor %}
-        -->
+        
     {% else %}
         <h3> We haven't been able to find any artists yet! <br>
     {% endif %}
-
+-->
 </div>
-       
+      
+
+
 {% endblock %}

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -47,7 +47,7 @@
     {% else %} {{ festival_name }} {% endif %}</h1>
 <iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ organizer }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
 {% if contributors %}
-    <h3>The respected contributors</h3>
+    <h3>Contributors</h3>
     {% for contributor in contributors %}
         <iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ contributor }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
     {% endfor %}

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -108,12 +108,13 @@
     {% elif is_org %}
         {% if 'contributors' not in all_users %}
             <input class="btn btn-success btn-lg" type="submit" value="SOLO generate"></input>
-        {% endif %}
+        {% else %}
+        <nav>
+        <ul>
+        <li id="login">
+            {% if all_users['all_ready'] == 0%}
 
-    <nav>
-    <ul>
-    <li id="login">
-        {% if all_users['all_ready'] == 0 %}
+    
           
             <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">NOT EVERYONE READY Generate</a>
 
@@ -122,15 +123,16 @@
             <p><input id="festivalSubmit" class="btn btn-primary btn-lg" type="submit" value="Generate" placeholder="placeholder" /></p>-->
         </form>
  
-        {% else %}
+            {% else %}
             <form id="login-form" action="{{ url_for('results', url_slug=url_slug) }}" method="post">
                 <p><input class="btn btn-primary btn-lg" type="submit" value="ALL READY Generate" /></p>
             </form>
 
-        {% endif %}  
+            {% endif %}  
          </li>
         </ul>
         </nav>
+        {% endif %}
     {% endif %}         
     </fieldset>
   </form>

--- a/library/templates/festival.html
+++ b/library/templates/festival.html
@@ -42,15 +42,22 @@
 
 <!-- Organizer avatar and contributor avatar -->
 
-<h1>{{ organizer }}'s
+<h1>{{ all_users['organizer']['userId'] }}'s
     {% if is_owner == true %} festival 
     {% else %} {{ festival_name }} {% endif %}</h1>
-<iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ organizer }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
-{% if contributors %}
+<iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ all_users['organizer']['userId'] }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
+{% if 'contributors' in all_users %}
     <h3>Contributors</h3>
-    {% for contributor in contributors %}
-        <iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ contributor }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
+    <div id='cover-container'>
+    {% for contributor in all_users['contributors'] %}
+        <div id='login-form text'>
+            <iframe src="https://embed.spotify.com/follow/1/?uri=spotify:user:{{ contributor }}&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
+            {% if contributor['ready'] == 1%}
+                <p>...is set!</p>
+            {% endif %}
+        </div> 
     {% endfor %}
+    </div>
 {% endif %}
 
 
@@ -73,13 +80,27 @@
         {{ params_form.variety(min=0, max=1, oninput="outputUpdate(value)")}}
         {{ params_form.adventurousness.label }}
         {{ params_form.adventurousness(min=0, max=1, oninput="outputUpdate(value)")}}                
+        {% if not is_owner %}
+            {% if all_users['contributors'][user]['ready'] == 0 %}
+                {{ params_form.ready_butt }}
+            {% else %}
+               {{ params_form.unready_butt }}
+            {% endif %}
+
         {% if is_owner %}
-            <input class="btn btn-success btn-lg" type="submit" value="Generate"></input>
-        {% else %}
-        <a href="#">
-            <input class="btn btn-success btn-lg" type="submit" value="Save Parameters"></input>
-        </a>
-        {% endif %}     	
+            {% if 'contributors' not in all_users %}
+                <input class="btn btn-success btn-lg" type="submit" value="Generate"></input>
+            {% elif all_users['all_ready'] == 0 %}
+                <li id="login">
+                    <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Generate</a>
+                    <form id="login-form" action="{{ url_for('results', url_slug=url_slug) }}" method="post">
+                    <p>Not everyone has shared their vibes! Are you sure?"</p>
+                    <p><input class="btn btn-primary btn-lg" type="submit" value="Generate" /></p>
+                    </form>
+            {% else %}
+                <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Generate</a>
+            {% endif %}   
+        {% endif %}         
         </fieldset>
       </form>
     </p>

--- a/library/templates/home.html
+++ b/library/templates/home.html
@@ -15,7 +15,6 @@
 
 {% block login %}
 
-<<<<<<< HEAD
 {% if login == false %}
 <div class="inner cover">
     <h1 class="cover-heading">Let's start your ideal Festival</h1>

--- a/library/templates/home.html
+++ b/library/templates/home.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-<!--
+
 {% block flash %}
 
     {% with messages = get_flashed_messages() %}
@@ -11,9 +11,22 @@
         {% endif %}
     {% endwith %}
 
-{% endblock %} -->
+{% endblock %}
 
 {% block login %}
+
+    {% if login == false %}
+    <div class="inner cover">
+            <h1 class="cover-heading">Let's start your ideal Festival</h1>
+            <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will
+                enjoy this musical experience.</p>
+            <br>
+                <p class="lead">Log in to create a festival, or join a friend's festival organization!
+                <a href="{{ oauth }}"><input name="submit" class="btn btn-success btn-lg" value="Log in!" type="button"></input></a>
+
+                <br><br>** insert flashy screenshots of a made festival or something **
+    </div>
+    {% else %}
 
     <div class="inner cover">
             <h1 class="cover-heading">Let's start your ideal Festival</h1>
@@ -21,7 +34,7 @@
                 enjoy this musical experience.</p>
             <br>
 
-                <a href="{{ url_for('home') }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
+                <a href="{{ url_for('new') }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
                         <nav>
                             <ul>
                                 <li id="login">
@@ -35,5 +48,6 @@
                         </nav>
     </div>
 
+    {% endif %}
 
 {% endblock %}

--- a/library/templates/home.html
+++ b/library/templates/home.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-
+<!--
 {% block flash %}
 
     {% with messages = get_flashed_messages() %}
@@ -11,53 +11,29 @@
         {% endif %}
     {% endwith %}
 
-{% endblock %}
+{% endblock %} -->
 
 {% block login %}
 
-{% if login == false %}
-<div class="inner cover">
-    <h1 class="cover-heading">Let's start your ideal Festival</h1>
-    <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will
-        enjoy this musical experience.</p>
-    <br>
+    <div class="inner cover">
+            <h1 class="cover-heading">Let's start your ideal Festival</h1>
+            <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will
+                enjoy this musical experience.</p>
+            <br>
 
-    <a href="{{ oauth }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
-    <nav>
-        <ul>
-            <li id="login">
-                <a class="btn btn-success btn-lg" href="{{ oauth }}" margin-right="40px" type="button">Join Festival  </a>
-                    <form id="login-form" action="{{ url_for('home', ) }}" method="post">
-                        <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
-                        <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
-                    </form>
-            </li>
-        </ul>
-    </nav>
-</div>
-	{% else %}
+                <a href="{{ url_for('home') }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
+                        <nav>
+                            <ul>
+                                <li id="login">
+                                    <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Join Festival  </a>
+                                        <form id="login-form" action="{{ url_for('home') }}" method="post">
+                                            <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
+                                            <p><input class="btn btn-primary btn-lg" id="festivalSubmit" type="submit" value="Submit" /></p>
+                                        </form>
+                                </li>
+                            </ul>
+                        </nav>
+    </div>
 
-<div class="inner cover">
-    <h1 class="cover-heading">Let's start your ideal Festival</h1>
-    <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will enjoy this musical experience.</p>
-    <br>
-
-    <a href="{{ url_for('new') }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
-        <nav>
-            <ul>
-                <li id="login">
-                    <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Join Festival  </a>
-                    <form id="login-form" action="{{ url_for('home') }}" method="post">
-                        <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
-                        <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
-                    </form>
-                </li>
-            </ul>
-        </nav>
-</div>
-
-{% endif %}
 
 {% endblock %}
-
-

--- a/library/templates/home.html
+++ b/library/templates/home.html
@@ -15,49 +15,48 @@
 
 {% block login %}
 
-    {% if login == false %}
-    <div class="inner cover">
-            <h1 class="cover-heading">Let's start your ideal Festival</h1>
-            <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will
-                enjoy this musical experience.</p>
-            <br>
+{% if login == false %}
+<div class="inner cover">
+    <h1 class="cover-heading">Let's start your ideal Festival</h1>
+    <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will
+        enjoy this musical experience.</p>
+    <br>
 
-                <a href="{{ oauth }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
-                        <nav>
-                            <ul>
-                                <li id="login">
-                                    <a class="btn btn-success btn-lg" href="{{ oauth }}" margin-right="40px" type="button">Join Festival  </a>
-                                        <form id="login-form" action="{{ url_for('home', ) }}" method="post">
-                                            <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
-                                            <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
-                                        </form>
-                                </li>
-                            </ul>
-                        </nav>
-    </div>
-   	{% else %}
+    <a href="{{ oauth }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
+    <nav>
+        <ul>
+            <li id="login">
+                <a class="btn btn-success btn-lg" href="{{ oauth }}" margin-right="40px" type="button">Join Festival  </a>
+                    <form id="login-form" action="{{ url_for('home', ) }}" method="post">
+                        <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
+                        <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
+                    </form>
+            </li>
+        </ul>
+    </nav>
+</div>
+	{% else %}
 
-    <div class="inner cover">
-            <h1 class="cover-heading">Let's start your ideal Festival</h1>
-            <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will
-                enjoy this musical experience.</p>
-            <br>
+<div class="inner cover">
+    <h1 class="cover-heading">Let's start your ideal Festival</h1>
+    <p class="lead">Festify will create the perfect festival base on the musical taste of the awesome people that will enjoy this musical experience.</p>
+    <br>
 
-                <a href="{{ url_for('new') }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
-                        <nav>
-                            <ul>
-                                <li id="login">
-                                    <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Join Festival  </a>
-                                        <form id="login-form" action="{{ url_for('home') }}" method="post">
-                                            <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
-                                            <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
-                                        </form>
-                                </li>
-                            </ul>
-                        </nav>
-    </div>
+    <a href="{{ url_for('new') }}"><input name="submit" class="btn btn-success btn-lg" value="Create Festival" type="button"></input></a>
+        <nav>
+            <ul>
+                <li id="login">
+                    <a class="btn btn-success btn-lg" href="#" margin-right="40px" type="button">Join Festival  </a>
+                    <form id="login-form" action="{{ url_for('home') }}" method="post">
+                        <p><input id="festi-text" class="text" type="text" name="festival_id" placeholder="Festival ID" /></p>
+                        <p><input class="btn btn-primary btn-lg" type="submit" value="Submit" /></p>
+                    </form>
+                </li>
+            </ul>
+        </nav>
+</div>
 
-    {% endif %}
+{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
**auth.py**
- OWNER IS DEPRECIATED --> is now organizer
- IS_OWNER IS DEPRECIATED -> is now is_org

**db.py**
- get_contributors() now returns a dictionary like so:
{'owner':{'userId': USERID, parameters},'all_ready':1/0, contributors{CONTUSERID1:{'parameter':0.4, etc}, CONTUSERID2:{'etc'}}

**festival.html**
- the festival organizer now (should) see a SOLO generate button if there are no contributors
- the feestival organizer now (should) see a ALL READY generate button if all_ready == 1
- the festival orgnaizer now (should) see a NOT ALL READY generate button which drops a "not everyone is ready! Are you sure? GENERATE" kind of button that is hidden before IF all_ready == 0
- festival contributors should see a "propose vision" button (which changes status to ready and saves params)
- festival contributors see a "change vision" button if ready = 1 (i.e. if propose vision was clicked). if "change vision" is clicked, the ready status STAYS == 1, but params can are updated
